### PR TITLE
Fix subscriptions

### DIFF
--- a/patches/web3-providers-ws+1.0.0-beta.37.patch
+++ b/patches/web3-providers-ws+1.0.0-beta.37.patch
@@ -4,7 +4,7 @@ patch-package
 @@ -25,6 +25,8 @@
  var _ = require('underscore');
  var errors = require('web3-core-helpers').errors;
-
+ 
 +var WsReconnector = require('websocket-reconnector');
 +
  var Ws = null;
@@ -52,27 +52,27 @@ patch-package
          return;
 @@ -299,15 +312,15 @@ WebsocketProvider.prototype.on = function (type, callback) {
              break;
-
+ 
          case 'connect':
 -            this.connection.onopen = callback;
 +            this.connection.addEventListener('open', callback);
              break;
-
+ 
          case 'end':
 -            this.connection.onclose = callback;
 +            this.connection.addEventListener('close', callback);
              break;
-
+ 
          case 'error':
 -            this.connection.onerror = callback;
 +            this.connection.addEventListener('error', callback);
              break;
-
+ 
          // default:
-@@ -316,7 +329,24 @@ WebsocketProvider.prototype.on = function (type, callback) {
+@@ -316,7 +329,26 @@ WebsocketProvider.prototype.on = function (type, callback) {
      }
  };
-
+ 
 -// TODO add once
 +/**
 + Subscribes to provider only once
@@ -85,20 +85,22 @@ patch-package
 +    var _this = this;
 +
 +    function onceCallback(event) {
-+        _this.removeListener(type, onceCallback);
++        setTimeout(function () {
++            _this.removeListener(type, onceCallback);
++        }, 0)
 +
 +        callback(event);
 +    }
 +
 +    this.on(type, onceCallback);
 +};
-
+ 
  /**
   Removes event listener
-@@ -336,7 +366,17 @@ WebsocketProvider.prototype.removeListener = function (type, callback) {
+@@ -336,7 +368,17 @@ WebsocketProvider.prototype.removeListener = function (type, callback) {
              });
              break;
-
+ 
 -        // TODO remvoving connect missing
 +        case 'connect':
 +            this.connection.removeEventListener('open', callback);
@@ -111,6 +113,6 @@ patch-package
 +        case 'error':
 +            this.connection.removeEventListener('error', callback);
 +            break;
-
+ 
          // default:
          //     this.connection.removeListener(type, callback);

--- a/src/plugins/eth/index.js
+++ b/src/plugins/eth/index.js
@@ -14,6 +14,9 @@ function createPlugin () {
     web3 = createWeb3(config, eventBus)
 
     checkChain(web3, config.chainId)
+      .then(function () {
+        debug('Chain ID is correct')
+      })
       .catch(function (err) {
         eventBus.emit('wallet-error', {
           inner: err,

--- a/src/plugins/eth/web3.js
+++ b/src/plugins/eth/web3.js
@@ -17,8 +17,8 @@ function createWeb3 (config, eventBus) {
       connected: true
     })
   })
-  web3.currentProvider.on('error', function (err) {
-    debug('Web3 provider connection error', err)
+  web3.currentProvider.on('error', function (event) {
+    debug('Web3 provider connection error', event.type || event)
     eventBus.emit('web3-connection-status-changed', {
       connected: false
     })

--- a/src/plugins/explorer/log-transaction.js
+++ b/src/plugins/explorer/log-transaction.js
@@ -4,8 +4,8 @@ const pDefer = require('p-defer')
 
 const createLogTransaction = queue =>
   function (promiEvent, from, meta) {
-  // PromiEvent objects shall be wrapped to avoid the promise chain to
-  // cast it to a plain promise
+    // PromiEvent objects shall be wrapped to avoid the promise chain to
+    // cast it to a plain promise
     if (promiEvent.once) {
       const deferred = pDefer()
 

--- a/src/plugins/explorer/transaction-status.js
+++ b/src/plugins/explorer/transaction-status.js
@@ -9,7 +9,7 @@ function getTransactionStatus (transaction, receipt) {
     receipt.status === null && // no Byzantinum fork
       transaction.input !== '0x' && // is contract call
       transaction.gas === receipt.gasUsed && // used all gas
-      !receipt.logs.length // and no any logs
+      !receipt.logs.length // and no logs
   )
 
   return !failed


### PR DESCRIPTION
The 'once' method on the websocket provider was removing the listeners (so those were called onlyt once) while the websocket object was iterating over the listeners list on 'connect'. Therefore, some listeners were not called. Removing the listeners in the next tick allows the websocket object to call all the listeners properly.
