### PR TITLE
Patch resubscription

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "metronome-wallet-core",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "check": "dependency-check . && dependency-check . --unused --no-dev --ignore-module websocket-reconnector",
     "coverage": "nyc --lines 95 --functions 95 --branches 95 --reporter=lcov --reporter=text npm test",
     "lint": "eslint --cache .",
-    "postinstall": "patch-package",
     "precommit": "npm run lint",
+    "prepare": "patch-package",
     "prepublishOnly": "npm run precommit && npm run prepush && tag-matches",
     "prepush": "npm run check",
     "test": "mocha"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metronome-wallet-core",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Core logic to develop an Ethereum Metronome wallet",
   "keywords": [
     "crypto",

--- a/patches/web3-core-subscriptions+1.0.0-beta.37.patch
+++ b/patches/web3-core-subscriptions+1.0.0-beta.37.patch
@@ -1,7 +1,7 @@
 patch-package
 --- a/node_modules/web3-core-subscriptions/src/subscription.js
 +++ b/node_modules/web3-core-subscriptions/src/subscription.js
-@@ -271,32 +271,11 @@ Subscription.prototype.subscribe = function() {
+@@ -271,32 +271,18 @@ Subscription.prototype.subscribe = function() {
                          _this.callback(null, output, _this);
                      });
                  } else {
@@ -29,6 +29,13 @@ patch-package
 +                    _this._resubscribe(err);
                  }
              });
++
++            // just in case the provider reconnects silently, resubscribe over the new connection
++            if (_this.options.requestManager.provider.once) {
++                _this.options.requestManager.provider.once('connect', function () {
++                    _this._resubscribe()
++                })
++            }
          } else {
 -          _this.callback(err, null, _this);
 -          _this.emit('error', err);
@@ -36,7 +43,7 @@ patch-package
          }
      });
  
-@@ -304,4 +283,36 @@ Subscription.prototype.subscribe = function() {
+@@ -304,4 +290,38 @@ Subscription.prototype.subscribe = function() {
      return this;
  };
  
@@ -66,7 +73,9 @@ patch-package
 +        });
 +    }
 +
-+    this.emit('error', err);
++    if (err) {
++        this.emit('error', err);
++    }
 +
 +    // call the callback, last so that unsubscribe there won't affect the emit above
 +    this.callback(err, null, this);


### PR DESCRIPTION
When the websocket connection silently reconnects (thanks to `websocket-reconnector`), the subscriptions have to be recreated over the new connection.

Also, changes the patching to `prepare` hook and bumps version to 2.0.1.