### PR TITLE
Use BlockScout API for ETC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "metronome-wallet-core",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -427,12 +427,19 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "axios": {
-      "version": "0.18.0",
-      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
       "requires": {
-        "follow-redirects": "^1.3.0",
-        "is-buffer": "^1.1.5"
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+        }
       }
     },
     "axios-cookiejar-support": {
@@ -698,11 +705,11 @@
       }
     },
     "bittrex-node": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/bittrex-node/-/bittrex-node-1.1.0.tgz",
-      "integrity": "sha512-UxF8Bz6AsI7jdTuajtbdsRClHhxSAWVE6c8SRTRa5a1wwwn7gZYnD0HrvyWMK3A2l4o85LneqiiUlDU9UkSLSA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bittrex-node/-/bittrex-node-1.2.1.tgz",
+      "integrity": "sha512-UCWr4pBt1NqIJFA4wSI8TDz9HbImSVUowijNJw6dR3K/USjPSYztlTHyZD3eF6wkBdkjXuic0MMXJzcZdR47Cg==",
       "requires": {
-        "axios": "0.18.0"
+        "axios": "0.19.0"
       }
     },
     "bl": {
@@ -3273,20 +3280,25 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
-      "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "requires": {
-        "debug": "^3.2.6"
+        "debug": "=3.1.0"
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -4162,7 +4174,8 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "is-callable": {
       "version": "1.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1839,6 +1839,12 @@
         "type-detect": "^4.0.0"
       }
     },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -5522,6 +5528,23 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "nock": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-10.0.6.tgz",
+      "integrity": "sha512-b47OWj1qf/LqSQYnmokNWM8D88KvUl2y7jT0567NB3ZBAZFz2bWp2PC81Xn7u8F2/vJxzkzNZybnemeFa7AZ2w==",
+      "dev": true,
+      "requires": {
+        "chai": "^4.1.2",
+        "debug": "^4.1.0",
+        "deep-equal": "^1.0.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.5",
+        "mkdirp": "^0.5.0",
+        "propagate": "^1.0.0",
+        "qs": "^6.5.1",
+        "semver": "^5.5.0"
+      }
+    },
     "node-emoji": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
@@ -6851,6 +6874,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-all-props/-/promise-all-props-1.0.1.tgz",
       "integrity": "sha1-wXHh5ZfDJG9XDzoTzsvQ9n5nbkg="
+    },
+    "propagate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
+      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
+      "dev": true
     },
     "proxy-addr": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metronome-wallet-core",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Core logic to develop an Ethereum Metronome wallet",
   "keywords": [
     "crypto",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "eslint-plugin-standard": "^4.0.0",
     "husky": "^2.3.0",
     "mocha": "^6.1.4",
+    "nock": "^10.0.6",
     "npm-check": "^5.8.0",
     "nyc": "^14.1.1",
     "patch-package": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "test": "mocha"
   },
   "dependencies": {
-    "axios": "^0.18.0",
+    "axios": "^0.19.0",
     "axios-cookiejar-support": "^0.4.2",
-    "bittrex-node": "^1.1.0",
+    "bittrex-node": "^1.2.1",
     "coincap-lib": "^1.0.0",
     "debug": "^4.1.1",
     "ethereumjs-wallet": "^0.6.3",

--- a/src/plugins/explorer/blockscout.js
+++ b/src/plugins/explorer/blockscout.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const axios = require('axios').default
+
+/**
+ *
+ * @param {string} address The address.
+ * @param {number} [startblock] The starting block.
+ * @param {number} [endblock] The ending block.
+ * @returns {Promise<string[]>} The list of transaction ids.
+ */
+function getTransactions (address, startblock, endblock) {
+  return axios({
+    baseURL: 'https://blockscout.com/etc/mainnet/api',
+    url: '/',
+    params: {
+      module: 'account',
+      action: 'txlist',
+      address,
+      sort: 'desc',
+      startblock,
+      endblock
+    }
+  }).then(function ({ data }) {
+    if (data.status !== '1' && data.message !== 'No transactions found') {
+      return Promise.reject(new Error(data.message))
+    }
+    return data.result.map(t => t.hash)
+  })
+}
+
+module.exports = { getTransactions }

--- a/test/src.plugins.explorer.indexer.spec.js
+++ b/test/src.plugins.explorer.indexer.spec.js
@@ -1,0 +1,94 @@
+'use strict'
+
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const nock = require('nock')
+
+const createIndexer = require('../src/plugins/explorer/indexer')
+
+const { randomAddress, randomTxId } = require('./utils')
+
+chai.use(chaiAsPromised).should()
+
+describe('Indexer', function () {
+  before(function () {
+    nock.disableNetConnect()
+  })
+
+  beforeEach(function () {
+    nock.cleanAll()
+  })
+
+  it('should query the Metronome indexer for transactions', function () {
+    const config = {
+      chainId: 1,
+      indexerUrl: 'http://localhost:3005',
+      useNativeCookieJar: true
+    }
+    const eventBus = null
+    const indexer = createIndexer(config, eventBus)
+
+    const address = randomAddress()
+    const transactions = [randomTxId()]
+
+    const scope = nock(config.indexerUrl)
+      .get(`/addresses/${address}/transactions`)
+      .query(() => true)
+      .reply(200, transactions)
+
+    return indexer.getTransactions(0, 1, address).then(function (list) {
+      list.should.deep.equals(transactions)
+      scope.done()
+    })
+  })
+
+  it('should query BlockScout for ETC mainnet transactions', function () {
+    const config = {
+      chainId: 61,
+      useNativeCookieJar: true
+    }
+    const eventBus = null
+    const indexer = createIndexer(config, eventBus)
+
+    const address = randomAddress()
+    const transactions = [randomTxId()]
+
+    const scope = nock('https://blockscout.com')
+      .get('/etc/mainnet/api/')
+      .query(q => q.address === address)
+      .reply(200, { status: '1', result: transactions.map(hash => ({ hash })) })
+
+    return indexer.getTransactions(0, 1, address).then(function (list) {
+      list.should.deep.equals(transactions)
+      scope.done()
+    })
+  })
+
+  it('should query BlockScout and parse errors', function () {
+    const config = {
+      chainId: 61,
+      useNativeCookieJar: true
+    }
+    const eventBus = null
+    const indexer = createIndexer(config, eventBus)
+
+    const address = randomAddress()
+    const message = 'Error message'
+
+    const scope = nock('https://blockscout.com')
+      .get('/etc/mainnet/api/')
+      .query(q => q.address === address)
+      .reply(200, { status: '0', result: [], message })
+
+    return indexer
+      .getTransactions(0, 1, address)
+      .should.be.rejectedWith(message)
+      .then(function () {
+        scope.done()
+      })
+  })
+
+  after(function () {
+    nock.enableNetConnect()
+  })
+})


### PR DESCRIPTION
Use BlockScout API to get all Ethereum Classic mainnet transactions of an address.

Once the Metronome indexing service for Ethereum Classic is in sync, this change should be reverted.