### PR TITLE
Emit chain hop start time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5033,9 +5033,9 @@
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "metronome-contracts": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/metronome-contracts/-/metronome-contracts-2.2.0.tgz",
-      "integrity": "sha512-DpRog9/5KWgJ58UfR3S4Eaf5EAMB9NhwLcSWCmGUf/MI1mdi1peULvuDs9kwu5TrQaLS7KVLp+tVvFXs6XZiOw=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/metronome-contracts/-/metronome-contracts-2.3.0.tgz",
+      "integrity": "sha512-ZsYCCu+6MhRD5E9cK25YN9Zeih+g+omVh19Le29nbu8TUCV2f3R1G311w+/fp6wDGV9ZvyiC3gif9AdpImTarw=="
     },
     "micromatch": {
       "version": "3.1.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "metronome-wallet-core",
-  "version": "2.2.4",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ethereumjs-wallet": "^0.6.3",
     "lodash": "^4.17.10",
     "merkletreejs": "0.0.25",
-    "metronome-contracts": "^2.2.0",
+    "metronome-contracts": "^2.3.0",
     "p-defer": "^1.0.0",
     "p-retry": "^3.0.1",
     "patch-package": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metronome-wallet-core",
-  "version": "2.2.4",
+  "version": "2.3.0",
   "description": "Core logic to develop an Ethereum Metronome wallet",
   "keywords": [
     "crypto",

--- a/src/plugins/metronome/index.js
+++ b/src/plugins/metronome/index.js
@@ -27,15 +27,30 @@ const {
   importMet,
   sendMet
 } = require('./token-api')
-const getAttestationThreshold = require('./validator-status')
-const getAuctionStatus = require('./auction-status')
-const getConverterStatus = require('./converter-status')
 const auctionEvents = require('./auction-events')
 const converterEvents = require('./converter-events')
+const getAttestationThreshold = require('./validator-status')
+const getAuctionStatus = require('./auction-status')
+const getChainHopStartTime = require('./porter-status')
+const getConverterStatus = require('./converter-status')
 const porterEvents = require('./porter-events')
 const validatorEvents = require('./validator-events')
 
+/**
+ * Creates an instance of the Metronome plugin.
+ *
+ * @returns {{start:Function,stop:Function}} The plugin top-level API.
+ */
 function createPlugin () {
+  /**
+   * Start the plugin.
+   *
+   * @param {object} params The start parameters.
+   * @param {object} params.config The configuration options.
+   * @param {object} params.eventBus The cross-plugin event emitter.
+   * @param {object} params.plugins All other plugins.
+   * @returns {{api:object,events:string[],name:string}} The plugin API.
+   */
   function start ({ config, eventBus, plugins }) {
     debug.enabled = config.debug
 
@@ -74,6 +89,10 @@ function createPlugin () {
         getAttestationThreshold(web3, chainId)
           .then(function (status) {
             eventBus.emit('attestation-threshold-updated', status)
+          }),
+        getChainHopStartTime(web3, chainId)
+          .then(function (status) {
+            eventBus.emit('chain-hop-start-time-updated', status)
           })
       ])
         .catch(function (err) {
@@ -166,6 +185,9 @@ function createPlugin () {
     }
   }
 
+  /**
+   * Stop the plugin.
+   */
   function stop () {}
 
   return {

--- a/src/plugins/metronome/porter-status.js
+++ b/src/plugins/metronome/porter-status.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const MetronomeContracts = require('metronome-contracts')
+
+/**
+ * Get the chain hop start time.
+ *
+ * @param {object} web3 A Web3.js instance.
+ * @param {string} chain The chain name.
+ * @returns {Promise<{chainHopStartTime:object}>} The start time in ms.
+ */
+function getChainHopStartTime (web3, chain) {
+  const { TokenPorter } = new MetronomeContracts(web3, chain)
+
+  return TokenPorter.methods
+    .chainHopStartTime()
+    .call()
+    .then(chainHopStartTime => ({
+      chainHopStartTime: Number.parseInt(chainHopStartTime, 10) * 1000
+    }))
+}
+
+module.exports = getChainHopStartTime


### PR DESCRIPTION
On each block, query the TokenPorter contract for chain hop start time and emit that time in milliseconds on the core event bus.

Event: `chain-hop-start-time-updated`
Data: `{ chainHopStartTime: 1560063262000 }`