### PR TITLE
Limit the concurrent calls during sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6427,6 +6427,14 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
+    "p-all": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-all/-/p-all-2.1.0.tgz",
+      "integrity": "sha512-HbZxz5FONzz/z2gJfk6bFca0BCiSRF8jU3yCsWOen/vR6lZjfPOu/e7L3uFzTW1i0H8TlC3vqQstEJPQL4/uLA==",
+      "requires": {
+        "p-map": "^2.0.0"
+      }
+    },
     "p-cancelable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
@@ -6465,6 +6473,11 @@
       "requires": {
         "p-limit": "^1.1.0"
       }
+    },
+    "p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
     },
     "p-retry": {
       "version": "3.0.1",
@@ -9066,7 +9079,7 @@
       "requires": {
         "underscore": "1.8.3",
         "web3-core-helpers": "1.0.0-beta.37",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
       }
     },
     "web3-shh": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "metronome-wallet-core",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "merkletreejs": "0.0.25",
     "metronome-contracts": "^2.4.0",
     "metronome-sdk-status": "^1.1.0",
+    "p-all": "^2.1.0",
     "p-defer": "^1.0.0",
     "p-retry": "^3.0.1",
     "patch-package": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metronome-wallet-core",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "Core logic to develop an Ethereum Metronome wallet",
   "keywords": [
     "crypto",


### PR DESCRIPTION
When syncing from scratch, several requests are sent to the node in parallel querying for all the relevant events logged in the blockchain. These requests can overload the node and the requests might time out. By controlling the amount of parallel requests, it is expected to reduce the load on the node so it can successfully respond all requests properly.

Resolve #25.