### PR TITLE
Perform the sync process in chunks so there are no timeouts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "metronome-wallet-core",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5551,7 +5551,7 @@
         },
         "find-up": {
           "version": "3.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
@@ -5566,7 +5566,7 @@
         },
         "invert-kv": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
           "dev": true
         },
@@ -5582,7 +5582,7 @@
         },
         "lcid": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
           "dev": true,
           "requires": {
@@ -5591,7 +5591,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
@@ -5628,7 +5628,7 @@
         },
         "os-locale": {
           "version": "3.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
           "dev": true,
           "requires": {
@@ -5648,7 +5648,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
@@ -5700,7 +5700,7 @@
         },
         "y18n": {
           "version": "4.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5551,7 +5551,7 @@
         },
         "find-up": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
@@ -5566,7 +5566,7 @@
         },
         "invert-kv": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
           "dev": true
         },
@@ -5582,7 +5582,7 @@
         },
         "lcid": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
           "dev": true,
           "requires": {
@@ -5591,7 +5591,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
@@ -5628,7 +5628,7 @@
         },
         "os-locale": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
           "dev": true,
           "requires": {
@@ -5648,7 +5648,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
@@ -5700,7 +5700,7 @@
         },
         "y18n": {
           "version": "4.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         },
@@ -6050,9 +6050,9 @@
       }
     },
     "p-timeout": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
-      "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+      "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
       "requires": {
         "p-finally": "^1.0.0"
       }
@@ -6062,6 +6062,11 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
+    },
+    "p-whilst": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-whilst/-/p-whilst-2.0.0.tgz",
+      "integrity": "sha512-vlz6N3zzlFXm8KHUxKTLNfQVBkEYFXn7dnGb770qKa1lG8O+2SOL5K75zxP7lkDHbbQNO67QotdH7WKmZPYAug=="
     },
     "package-hash": {
       "version": "3.0.0",
@@ -7600,6 +7605,16 @@
             "timed-out": "^4.0.0",
             "url-parse-lax": "^1.0.0",
             "url-to-options": "^1.0.1"
+          },
+          "dependencies": {
+            "p-timeout": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
+              "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+              "requires": {
+                "p-finally": "^1.0.0"
+              }
+            }
           }
         },
         "p-cancelable": {
@@ -8840,7 +8855,7 @@
       "requires": {
         "underscore": "1.9.1",
         "web3-core-helpers": "1.2.1",
-        "websocket": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e"
+        "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
       },
       "dependencies": {
         "underscore": {

--- a/package.json
+++ b/package.json
@@ -73,5 +73,8 @@
     "nyc": "^14.1.1",
     "proxyquire": "^2.1.3",
     "randomstring": "^1.1.5"
+  },
+  "engines": {
+    "node": ">=8 <=10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metronome-wallet-core",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "description": "Core logic to develop an Ethereum Metronome wallet",
   "keywords": [
     "crypto",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "p-all": "^2.1.0",
     "p-defer": "^1.0.0",
     "p-retry": "^3.0.1",
+    "p-timeout": "^2.0.1",
+    "p-whilst": "^2.0.0",
     "patch-package": "^5.1.1",
     "promise-all-props": "^1.0.1",
     "safe-exchange-rate": "^1.0.0",

--- a/test/src.plugins.explorer.spec.js
+++ b/test/src.plugins.explorer.spec.js
@@ -349,7 +349,7 @@ describe('Explorer plugin', function () {
 
   describe('refreshAllTransactions', function () {
     it('should start from birthblock', function (done) {
-      this.timeout(80000)
+      this.timeout(40000)
       const chain = 'ropsten'
       const { birthblock } = MetronomeContracts[chain].Auctions
       const latestBlock = 5000000

--- a/test/src.plugins.explorer.spec.js
+++ b/test/src.plugins.explorer.spec.js
@@ -349,6 +349,7 @@ describe('Explorer plugin', function () {
 
   describe('refreshAllTransactions', function () {
     it('should start from birthblock', function (done) {
+      this.timeout(80000)
       const chain = 'ropsten'
       const { birthblock } = MetronomeContracts[chain].Auctions
       const latestBlock = 5000000
@@ -359,7 +360,9 @@ describe('Explorer plugin', function () {
       const responses = {
         eth_getBlockByNumber: () => ({ number: latestBlock }),
         eth_getLogs ({ fromBlock, toBlock }) {
-          receivedFromBlock = Web3.utils.hexToNumber(fromBlock)
+          if (receivedFromBlock === undefined) {
+            receivedFromBlock = Web3.utils.hexToNumber(fromBlock)
+          }
           receivedToBlock = Web3.utils.hexToNumber(toBlock)
           return []
         }


### PR DESCRIPTION
This PR updates the logic of calling `getPastEvents()` (used in syncing transactions and refreshing transactions) to perform this operation in chunks instead of the whole range by default. This will allow new users who have to sync the whole blockchain or those who haven't synced in a long time to be able to complete the sync process (even though it might take some time)

References the following issues

- https://github.com/autonomoussoftware/metronome-wallet-desktop/issues/480 (possibly fixed by this, once the desktop project is updated)
- https://github.com/autonomoussoftware/metronome-wallet-mobile/issues/115 (same as previous one)
- https://github.com/autonomoussoftware/metronome-wallet-mobile/issues/115 (same as previous one)